### PR TITLE
An example that runs against the OTB-2015 dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .DS_Store
+testdata/

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,0 +1,162 @@
+extern crate image;
+extern crate imageproc;
+extern crate mosse;
+extern crate rusttype;
+extern crate time;
+
+use image::Rgba;
+use imageproc::drawing::{draw_cross_mut, draw_hollow_rect_mut, draw_text_mut};
+use imageproc::rect::Rect;
+use mosse::{MosseTrackerSettings, MultiMosseTracker};
+use rusttype::{Font, Scale};
+use std::env;
+use std::time::Instant;
+
+fn main() {
+    // Collect all elements in the iterator that contains the command line arguments
+    let args: Vec<String> = env::args().collect();
+
+    // remove the first element from the list of arguments, which is the call to the binary
+    let inputfiles = &args[1..];
+
+    if inputfiles.len() == 0 {
+        panic!("no input files specified");
+    }
+    let mut images = inputfiles.iter().map(|path| image::open(path).unwrap());
+    let first = images.next().unwrap();
+
+    // initialize a new model
+    let (width, height) = first.to_rgb8().dimensions();
+    let window_size = 64; //size of the tracking window
+    let psr_thresh = 7.0; // how high the psr must be before prediction is considered succesful.
+    let settings = MosseTrackerSettings {
+        window_size: window_size,
+        width,
+        height,
+        regularization: 0.001,
+        learning_rate: 0.05,
+        psr_threshold: psr_thresh,
+    };
+    let desperation_threshold = 3; // how many frames the tracker should try to re-acquire the target until we consider it failed
+    let mut multi_tracker = MultiMosseTracker::new(settings, desperation_threshold);
+
+    // coordinates of the target objects to track in the intial frame
+    let target_coords = vec![
+        (143, 766),
+        (232, 653),
+        (291, 731),
+        (1298, 664),
+        (479, 642),
+        (574, 629),
+        (666, 627),
+        (762, 609),
+    ];
+
+    // Add all the targets  on the first image to the multitracker
+    let first_img = first.to_luma8();
+    for (i, coords) in target_coords.into_iter().enumerate() {
+        let start = Instant::now();
+        multi_tracker.add_or_replace_target(i as u32, coords, &first_img);
+        println!(
+            "Added object on initial frame to multi-tracker in {} ms",
+            start.elapsed().as_millis()
+        );
+    }
+
+    for (i, dyn_img) in images.enumerate() {
+        // add leading zeroes for easier downstream proc with ffmpeg
+        let img_id = format!("{:<04}", i + 1);
+
+        // track the objects on the new frame
+        let start = Instant::now();
+        let predictions = multi_tracker.track(&dyn_img.to_luma8());
+
+        println!(
+            "Processed sample image no. {} in {} ms. Active trackers: {}.",
+            img_id,
+            start.elapsed().as_millis(),
+            multi_tracker.size(),
+        );
+
+        let mut img_copy = dyn_img;
+        for (obj_id, pred) in predictions.iter() {
+            // color changes when psr is low
+            let mut color = Rgba([125u8, 255u8, 0u8, 0u8]);
+            if pred.psr < psr_thresh {
+                color = Rgba([255u8, 0u8, 0u8, 0u8])
+            }
+
+            // Indicate the locations of the predictions by drawing on the image.
+            draw_cross_mut(
+                &mut img_copy,
+                Rgba([255u8, 0u8, 0u8, 0u8]),
+                pred.location.0 as i32,
+                pred.location.1 as i32,
+            );
+            draw_hollow_rect_mut(
+                &mut img_copy,
+                Rect::at(
+                    pred.location.0.saturating_sub(window_size / 2) as i32,
+                    pred.location.1.saturating_sub(window_size / 2) as i32,
+                )
+                .of_size(window_size, window_size),
+                color,
+            );
+
+            let font_data = include_bytes!("./Arial.ttf");
+            let font = Font::try_from_bytes(font_data as &[u8]).unwrap();
+
+            const FONT_SCALE: f32 = 10.0;
+
+            // render the object ID
+            draw_text_mut(
+                &mut img_copy,
+                Rgba([125u8, 255u8, 0u8, 0u8]),
+                (pred.location.0 - (window_size / 2)).try_into().unwrap(),
+                (pred.location.1 - (window_size / 2)).try_into().unwrap(),
+                Scale::uniform(FONT_SCALE),
+                &font,
+                &format!("#{}", obj_id),
+            );
+
+            // render the PSR on top of the rectangle
+            draw_text_mut(
+                &mut img_copy,
+                color,
+                (pred.location.0 - (window_size / 2)).try_into().unwrap(),
+                (pred.location.1 - (window_size / 2) + FONT_SCALE as u32)
+                    .try_into()
+                    .unwrap(),
+                Scale::uniform(FONT_SCALE),
+                &font,
+                &format!("PSR: {:.2}", pred.psr),
+            );
+
+            println!("Object {} PSR: {}", obj_id, pred.psr)
+        }
+
+        // additional debug info
+        #[cfg(debug_assertions)]
+        {
+            // save the filters
+            multi_tracker
+                .dump_filter_reals()
+                .iter()
+                .enumerate()
+                .for_each(|(i, f)| {
+                    f.save(format!("filter_real_obj{}_fig{}.png", i, img_id))
+                        .unwrap()
+                })
+        }
+
+        img_copy
+            .save(format!("predicted_image_{}.png", img_id))
+            .unwrap();
+
+        // Break off multi tracker if all targets lost
+        if multi_tracker.size() == 0 {
+            println!("No more active trackers. Stopping demo.");
+            break;
+        }
+    }
+}


### PR DESCRIPTION
A bit of context: there was a proposal to implement MOSSE as part of the Rust London Hack and Learn last night (see https://www.meetup.com/Rust-London-User-Group/events/288436078/ and https://github.com/rust-ldn/rust-hack-and-learn/issues/19 for more informaiton). We were about halfway through reading the paper together when we realized that you had already written an implementation.

We couldn't find the source video for your `examples/demo.rs` so we weren't sure what the best way to evaluate things was (should I open a separate issue for this?).

I did some searching and found this benchmark dataset: http://cvlab.hanyang.ac.kr/tracker_benchmark/datasets.html  , and I wrote some code to run mosse-tracker against it. 

Open questions/todos (not sure which of these should be done as part of this PR, and which should be done later):

- [ ] The server that hosts this dataset is super-slow. Does anyone know of any faster mirrors?
- [ ] We should probably print out a number at the end, so that it can be compared against other benchmarked algorithms
- [ ] The bash script to download and unzip the sequences is a bit ugly. There seems to be a python script at https://cv.gluon.ai/build/examples_datasets/otb2015.html but I've not tried it.
- [ ] I'm still downloading things, so I've not actually tested it against the whole dataset yet.
- [ ] I didn't make it handle multiple object tracking yet
- [ ] I haven't looked into this yet: "In most sequences the first row corresponds to the first frame and the last row to the last frame, except the following sequences: David(300:770), Football1(1:74), Freeman3(1:460), Freeman4(1:283)."

Is this a useful thing to be doing, or should we just update the instructions to get examples/demo.rs working with the original video, and call it a day?